### PR TITLE
特定の記事のお気に入り登録ボタン、お気に入り記事一覧画面の実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,10 @@ import Content from "./pages/Content";
 const styles = {
   root: {
     backgroundColor: '#f7f7f7',
-    display: 'flex',
-    flexDirection: 'column',
     minHeight: '100vh'
   },
   mainContainer: {
-    flex: '1',
+    display: 'flex',
     justifyContent: 'center',
     padding: '20px 10px',
   },
@@ -23,20 +21,20 @@ const styles = {
 function App() {
 
   return (
-    <Grid container direction='column' style={styles.root}>
+    <div style={styles.root}>
       <AuthProvider>
         <UserDataProvider>
           <CssBaseline />
           <BrowserRouter>
             <Header />
-            <Grid container style={styles.mainContainer}>
+            <div style={styles.mainContainer}>
               <Content />
-            </Grid>
+            </div>
             {/* <Footer /> */}
           </BrowserRouter>
         </UserDataProvider>
       </AuthProvider>
-    </Grid>
+    </div>
   );
 }
 

--- a/src/components/Favorite/FavoriteButton.jsx
+++ b/src/components/Favorite/FavoriteButton.jsx
@@ -1,0 +1,83 @@
+import React, { useContext, useEffect, useState } from 'react'
+import clientApi from '../../api/client';
+import { Button } from '@mui/material';
+import Cookies from 'js-cookie';
+import { AuthContext } from '../../contexts/AuthContext';
+
+const FavoriteButton = ({ post_id, author_id }) => {
+  const [favorite, setFavorite] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const { currentUser } = useContext(AuthContext);
+
+  useEffect(() => {
+    const fetchFavoriteStatus = async () => {
+      try {
+        const headers = {
+          'access-token': Cookies.get('_access_token'),
+          'client': Cookies.get('_client'),
+          'uid': Cookies.get('_uid'),
+        };
+
+        const user_id = currentUser.id;
+        const response = await clientApi.get(`/posts/${post_id}/favorite_status?user_id=${user_id}`)
+
+        setFavorite(response.data.isFavorite);
+        console.log('favorite', favorite);
+
+      }  catch (error) {
+        console.error('お気に入り状態の取得に失敗しました', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFavoriteStatus();
+  }, [currentUser.id, post_id]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  const handleFavorite = async () => {
+    try {
+      const headers = {
+        'access-token': Cookies.get('_access_token'),
+        'client': Cookies.get('_client'),
+        'uid': Cookies.get('_uid'),
+      };
+
+      const requestData = {
+        post_id: post_id
+      }
+
+      console.log('Request Data:', requestData);
+
+      if (favorite) {
+        await clientApi.delete(`/posts/${post_id}/unfavorite`, {
+          headers: headers
+        });
+      } else {
+        await clientApi.post(`/posts/${post_id}/favorite`, requestData, {
+          headers: headers
+        });
+      }
+
+      setFavorite(prevFavorite => !prevFavorite);
+    } catch (error) {
+      console.error('お気に入りの操作に失敗しました', error);
+    }
+  }
+
+  return (
+    <Button
+      onClick={() => handleFavorite()}
+      variant='contained'
+      color='success'
+      disabled={currentUser.id ===  author_id}
+    >
+      {favorite ? 'お気に入りを解除する' : 'お気に入り登録する'}
+    </Button>
+  )
+}
+
+export default FavoriteButton

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -155,14 +155,17 @@ const Header = () => {
       >
         { isSignedIn && (
           <>
-            {/* <MenuItem component={Link} to="/account" onClick={() => setAnchorEl(null)}>
+            <MenuItem component={Link} to="/account" onClick={() => setAnchorEl(null)}>
               アカウント
-            </MenuItem> */}
+            </MenuItem>
             <MenuItem component={Link} to="/new/post" onClick={() => setAnchorEl(null)}>
               記事を投稿する
             </MenuItem>
             <MenuItem component={Link} to="/posts/my_posts" onClick={() => setAnchorEl(null)}>
               投稿した記事
+            </MenuItem>
+            <MenuItem component={Link} to="/posts/favorite" onClick={() => setAnchorEl(null)}>
+              お気に入り登録した記事
             </MenuItem>
             <MenuItem
               onClick={() => {

--- a/src/components/MyPost.jsx
+++ b/src/components/MyPost.jsx
@@ -1,16 +1,64 @@
 import React, { useEffect, useState } from 'react'
-import { Grid, CircularProgress, Typography, Box, Button } from '@mui/material';
+import { Grid, CircularProgress, Typography, Box, Button, Card } from '@mui/material';
 import { Link, useNavigate } from 'react-router-dom';
 import clientApi from '../api/client';
 import Cookies from 'js-cookie';
 
 const styles = {
+  container: {
+    width: '100%',
+    maxWidth: '1300px',
+  },
+  header: {
+    textAlign: 'center',
+  },
+  mainContainer: {
+    width: '100%',
+    display: 'flex',
+    minHeight: '100vh',
+    justifyContent: 'center',
+  },
+  contentContainer: {
+    maxWidth: '1000px',
+  },
+  newButton: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    margin: '20px',
+  },
+  postCard: {
+    padding: '20px',
+    margin: '0 20px 20px 0',
+  },
+  postInfo: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  postLink: {
+    textDecoration: 'none',
+    color: 'inherit',
+  },
+  postInfoContent: {
+    marginLeft: '20px',
+  },
+  postBody: {
+    marginTop: '20px',
+  },
+  myPostButtons: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '10px',
+  },
+  sideBar: {
+    maxWidth: '300px',
+    width: '100%',
+  },
   spinnerContainer: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     minHeight: '100vh',
-  }
+  },
 }
 
 const MyPost = () => {
@@ -82,31 +130,55 @@ const MyPost = () => {
 
   return (
     <>
-      <h2>自分の投稿一覧</h2>
-      {postData.map((post) => (
-        <div key={post.id}>
-          <Link to={`/posts/${post.id}`}>
-            <Box mb={2}>
-              <Typography variant="h4">{post.title}</Typography>
-              <Typography>{post.createdAt}</Typography>
-              {post.image.url ? (
-                <img src={post.image.url} style={{ width: '200px' }} alt="post thumbnail" />
-              ) : (
-                <img src='/default_post_image.png' style={{ width: '200px' }} alt="post thumbnail" />
-              )}
-              <Typography>
-                {post.body.length > 50 ? `${post.body.slice(0, 50)}...` : post.body}
-              </Typography>
-            </Box>
-          </Link>
-          <Button variant='outlined' onClick={() => handleEditClick(post.id)}>
-            編集
-          </Button>
-          <Button variant='outlined' onClick={() => handleDeleteClick(post.id)}>
-            削除
-          </Button>
+      <div style={styles.container}>
+        <h2 style={styles.header}>投稿した記事</h2>
+        <div style={styles.mainContainer}>
+          <div>
+            <div style={styles.newButton}>
+              <Button
+                variant="contained"
+                color="info"
+                component={Link}
+                to={'/new/post'}
+              >
+                新規投稿する
+              </Button>
+            </div>
+            {postData.map((post) => (
+              <div key={post.id}>
+                <Card style={styles.postCard}>
+                  <Link to={`/posts/${post.id}`} style={styles.postLink}>
+                    <div style={styles.postInfo}>
+                      <div>
+                        {post.image.url ? (
+                          <img src={post.image.url} style={{ width: '200px' }} alt="post thumbnail" />
+                        ) : (
+                          <img src='/default_post_image.png' style={{ width: '200px' }} alt="post thumbnail" />
+                        )}
+                      </div>
+                      <div style={styles.postInfoContent}>
+                        <Typography variant="h4">{post.title}</Typography>
+                        <Typography>{post.createdAtFormatted} コメント{post.comments.length}件</Typography>
+                        <Typography style={styles.postBody}>
+                          {post.body.length > 50 ? `${post.body.slice(0, 50)}...` : post.body}
+                        </Typography>
+                      </div>
+                    </div>
+                  </Link>
+                  <div style={styles.myPostButtons}>
+                    <Button variant='outlined' color='primary'onClick={() => handleEditClick(post.id)}>
+                      編集
+                    </Button>
+                    <Button variant='outlined' color='error'onClick={() => handleDeleteClick(post.id)}>
+                      削除
+                    </Button>
+                  </div>
+                </Card>
+              </div>
+            ))}
+          </div>
         </div>
-      ))}
+      </div>
     </>
   )
 }

--- a/src/components/Post/EditPost.jsx
+++ b/src/components/Post/EditPost.jsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import axios from 'axios';
-import { TextField, Button, Box, Typography, Card, CardHeader, Avatar } from '@mui/material';
+import { TextField, Button,Card, CardHeader } from '@mui/material';
 import clientApi from '../../api/client';
 import Cookies from 'js-cookie';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 const styles = {
   container: {
@@ -18,6 +17,11 @@ const styles = {
   },
   card: {
     padding: '2rem',
+  },
+  editButtons: {
+    marginTop: '20px',
+    display: 'flex',
+    justifyContent: 'space-between',
   }
 }
 
@@ -135,13 +139,21 @@ const EditPost = () => {
           <div>
             {thumbnailPreview && <img alt='サムネイルプレビュー' src={thumbnailPreview} width='300px' />}
           </div>
-          <div>
+          <div style={styles.editButtons}>
+            <Button
+              variant="contained"
+              color="inherit"
+              size='large'
+              component={Link}
+              to={'/posts/my_posts'}
+            >
+              戻る
+            </Button>
             <Button
               type="submit"
               variant="contained"
               size="large"
               color="primary"
-              style={{ marginTop: '1rem' }}
             >
               更新する
             </Button>

--- a/src/components/Post/FavoritePosts.jsx
+++ b/src/components/Post/FavoritePosts.jsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useState } from 'react'
-import { Grid, CircularProgress, Typography, Box, Card } from '@mui/material';
+import { Grid, CircularProgress, Typography, Card } from '@mui/material';
 import clientApi from '../../api/client';
 import { Link, useParams } from 'react-router-dom';
+import Cookies from 'js-cookie';
 
 const styles = {
   container: {
     width: '100%',
     maxWidth: '1300px',
-    // display: 'flex',
-    // flexDirection: 'column',
-    // alignItems: 'center'
   },
   header: {
     textAlign: 'center'
@@ -54,19 +52,20 @@ const styles = {
 }
 
 const PostByUser = () => {
-  const { blog_id } = useParams();
   const [postData, setPostData] = useState([]);
   const [postLoading, setPostLoading] = useState(true);
 
   const fetchPosts = async () => {
     try {
-      const response = await clientApi.get('posts/index_by_user', {
-        params: {
-          user_id: blog_id,
-        },
-      });
+      const headers = {
+        'access-token': Cookies.get('_access_token'),
+        'client': Cookies.get('_client'),
+        'uid': Cookies.get('_uid'),
+      };
 
-      console.log('params', blog_id)
+      const response = await clientApi.get('posts/favorite_posts', {
+        headers: headers,
+      });
 
       console.log(response.data);
 
@@ -93,6 +92,7 @@ const PostByUser = () => {
   return (
     <>
       <div style={styles.container}>
+        <h2 style={styles.header}>お気に入り</h2>
         <div style={styles.mainContainer}>
           <div>
             {postData.map((post) => (
@@ -119,11 +119,6 @@ const PostByUser = () => {
                 </Card>
               </div>
             ))}
-          </div>
-          <div style={styles.sideBar}>
-            <Card>
-              プロフィールが入ります。
-            </Card>
           </div>
         </div>
       </div>

--- a/src/components/Post/ShowPost.jsx
+++ b/src/components/Post/ShowPost.jsx
@@ -4,6 +4,7 @@ import clientApi from '../../api/client';
 import { AuthContext } from '../../contexts/AuthContext';
 import { Card, CircularProgress } from '@mui/material';
 import CommentSection from '../Comment/CommentSection';
+import FavoriteButton from '../Favorite/FavoriteButton';
 
 const styles = {
   spinnerContainer: {
@@ -85,6 +86,7 @@ const ShowPost = () => {
             <Card style={styles.titleCard}>
               <h2>{postData.title}</h2>
               <span>{postData.createdAtFormatted}</span>
+              <FavoriteButton post_id={postData.id} author_id={postData.user.id} />
             </Card>
             <div style={styles.body}>
               <Card style={styles.bodyCard}>

--- a/src/components/Post/ShowPost.jsx
+++ b/src/components/Post/ShowPost.jsx
@@ -28,8 +28,13 @@ const styles = {
     padding: '10px 20px',
     marginBottom: '20px',
   },
+  titleCardContent: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
   bodyText: {
-    margin: '40px 0'
+    margin: '40px 0',
   },
   body: {
     marginBottom: '20px',
@@ -85,8 +90,14 @@ const ShowPost = () => {
           <div style={styles.contentContainer}>
             <Card style={styles.titleCard}>
               <h2>{postData.title}</h2>
-              <span>{postData.createdAtFormatted}</span>
-              <FavoriteButton post_id={postData.id} author_id={postData.user.id} />
+              <div style={styles.titleCardContent}>
+                {/* <div> */}
+                  <span>{postData.createdAtFormatted} コメント{postData.comments.length}件</span>
+                {/* </div> */}
+                {/* <div> */}
+                  <FavoriteButton post_id={postData.id} author_id={postData.user.id} />
+                {/* </div> */}
+              </div>
             </Card>
             <div style={styles.body}>
               <Card style={styles.bodyCard}>

--- a/src/pages/Content.jsx
+++ b/src/pages/Content.jsx
@@ -9,6 +9,7 @@ import PostByUser from '../components/Post/PostByUser'
 import ShowPost from '../components/Post/ShowPost'
 import MyPost from '../components/MyPost'
 import EditPost from '../components/Post/EditPost'
+import FavoritePosts from '../components/Post/FavoritePosts'
 
 
 const styles = {
@@ -35,6 +36,7 @@ const Content = () => {
         <Route path='/posts/my_posts' element={<Paper style={styles.paper}><MyPost /></Paper>} />
         <Route path='/posts/:post_id' element={<ShowPost />} />
         <Route path='/posts/edit/:post_id' element={<EditPost />} />
+        <Route path='/posts/favorite' element={<FavoritePosts />} />
       </Routes>
     </>
   )


### PR DESCRIPTION
### 【実装内容】
**特定の記事のお気に入り登録ボタン**
お気に入り状態を確認して、未登録なら「お気に入り登録する」、登録済みなら「お気に入りを解除する」と表示されるようなボタンを実装しました。

POST /api/posts/{post_id}/favorites：お気に入り登録
DELETE /api/posts/{post_id}/favorites：お気に入り解除
GET /posts/{post_id}/favorite_status：お気に入り状態取得

**お気に入り記事一覧画面**
自分がお気に入り登録した記事を表示する画面を追加しました。

GET posts/favorite_posts：自分のお気に入りしたブログ記事一覧取得